### PR TITLE
Add support for direct icon URLs

### DIFF
--- a/main.go
+++ b/main.go
@@ -400,11 +400,20 @@ func updateMetricsLoop() {
 
 func getIconHTML(icon, name string) template.HTML {
 	if icon == "" {
-		return template.HTML(fmt.Sprintf(`<span class="iconify" data-icon="mdi:application" data-width="36" data-height="36"></span>`))
+		return template.HTML(`<span class="iconify" data-icon="mdi:application" data-width="36" data-height="36"></span>`)
 	}
+
 	if strings.HasPrefix(icon, "mdi-") {
-		return template.HTML(fmt.Sprintf(`<span class="iconify" data-icon="mdi:%s" data-width="36" data-height="36"></span>`, strings.TrimPrefix(icon, "mdi-")))
+		return template.HTML(fmt.Sprintf(
+			`<span class="iconify" data-icon="mdi:%s" data-width="36" data-height="36"></span>`,
+			strings.TrimPrefix(icon, "mdi-"),
+		))
 	}
+
+	if strings.HasPrefix(icon, "http://") || strings.HasPrefix(icon, "https://") {
+		return template.HTML(fmt.Sprintf(`<img src='%s' alt='%s'>`, icon, name))
+	}
+
 	url := fmt.Sprintf("https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/%s", icon)
 	return template.HTML(fmt.Sprintf(`<img src='%s' alt='%s'>`, url, name))
 }


### PR DESCRIPTION
Config:
```
services:
  - group: "Management"
    items:
      - name: "Kaneo"
        url: "https://kaneo.mydomain.su"
        description: "Kanban project management"
        icon: "https://kaneo.mydomain.su/favicon-96x96.png"

      - name: "Docmost"
        url: "https://docmost.mydomain.su"
        description: "Collaborative wiki and documentation"
        icon: "https://docmost.mydomain.su/icons/favicon-32x32.png"
...
```

Before:
<details>
  <summary>Screenshot</summary>
<img width="600" alt="Screenshot" src="https://github.com/user-attachments/assets/30c214d2-eb3e-4464-80f7-266d628d56a9" />
</details>

After:
<details>
  <summary>Screenshot</summary>
  <img width="600" alt="Screenshot" src="https://github.com/user-attachments/assets/9ea20fac-563a-48f3-8293-74c31397c57a" />
</details>


