### PR TITLE
Add support for separate ping URLs and optional ping disabling

### DIFF
--- a/main.go
+++ b/main.go
@@ -103,6 +103,7 @@ type Settings struct {
 	Title     string `yaml:"title"`
 	Port      int    `yaml:"port"`       // Server port (default: 8080)
 	ShowTitle bool   `yaml:"show_title"` // Show title in header (default: true)
+	Favicon   string `yaml:"favicon"`    // Favicon URL or data URI (default: home emoji)
 }
 
 // SystemMetrics holds all system metrics collected for display

--- a/static/app.js
+++ b/static/app.js
@@ -146,6 +146,18 @@ function performSearch(query) {
 }
 
 document.addEventListener('DOMContentLoaded', function() {
+    // Lock body height to prevent viewport changes from affecting background
+    const lockBodyHeight = () => {
+        document.body.style.height = `${window.innerHeight}px`;
+    };
+    
+    // Set initial height on load
+    lockBodyHeight();
+    window.addEventListener('load', lockBodyHeight);
+    
+    // Only update on orientation changes, not on scroll
+    window.addEventListener('orientationchange', () => setTimeout(lockBodyHeight, 100));
+    
     // Load saved theme and layout
     loadTheme();
     loadLayout();

--- a/static/styles.css
+++ b/static/styles.css
@@ -8,21 +8,28 @@
 
 html {
     height: 100%;
+    overflow: hidden;
 }
 
 body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
     background: #1a1a2e;
     color: var(--text-primary);
-    min-height: 100%;
+    height: 100%;
     padding: 1rem;
-    position: relative;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
     display: flex;
     flex-direction: column;
+    overflow-y: auto;
+    overflow-x: hidden;
+    -webkit-overflow-scrolling: touch;
 }
 
-body::before {
-    content: '';
+.fixed-bg {
     position: fixed;
     top: 0;
     left: 0;
@@ -35,6 +42,9 @@ body::before {
     filter: blur(2px) saturate(100%) brightness(70%);
     opacity: 0.5;
     z-index: -1;
+    /* Prevent background from resizing on mobile */
+    -webkit-backface-visibility: hidden;
+    backface-visibility: hidden;
 }
 
 .container {

--- a/static/styles.css
+++ b/static/styles.css
@@ -451,6 +451,11 @@ section {
         opacity: 1;
     }
 
+    &.status-unknown::before {
+        background: var(--text-secondary);
+        opacity: 0.5;
+    }
+
     &:hover {
         transform: translateY(-2px);
         box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
@@ -563,6 +568,12 @@ section {
 .status-down {
     color: var(--status-down);
     font-weight: 600;
+}
+
+.status-unknown {
+    color: var(--text-secondary);
+    font-weight: 600;
+    opacity: 0.7;
 }
 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,6 +10,7 @@
     <script src="/static/app.js"></script>
 </head>
 <body>
+    <div class="fixed-bg"></div>
     <header class="container">
         {{if .Config.Settings.ShowTitle}}
         <h1>{{.Config.Settings.Title}}</h1>

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,6 +4,11 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{.Config.Settings.Title}}</title>
+    {{if .Config.Settings.Favicon}}
+    <link rel="icon" type="image/svg+xml" href="{{.Config.Settings.Favicon}}">
+    {{else}}
+    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E🏠%3C/text%3E%3C/svg%3E">
+    {{end}}
     <link rel="stylesheet" href="/static/styles.css?v=29">
     <link rel="stylesheet" id="theme-css" href="">
     <script src="/static/iconify.min.js"></script>


### PR DESCRIPTION
This enhancement adds flexibility to service health checking:

- Added 'pingUrl' field: Allows specifying a different URL for health checks than the one used for browser navigation. Useful when services have internal cluster URLs that should be used for monitoring while external URLs are used for user access.

- Added 'ping' boolean field: Allows disabling health checks entirely for services where monitoring is not applicable or desired. When set to false, services display in an 'unknown' state.

- Default behavior: Services without 'pingUrl' use their main 'url' for health checks, maintaining backward compatibility.

- Visual styling: Added 'status-unknown' CSS class for services with disabled or unavailable health checks, providing clear visual distinction from up/down states.