### PR TITLE
Fix mobile background resizing with fixed body approach

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -146,6 +146,18 @@ function performSearch(query) {
 }
 
 document.addEventListener('DOMContentLoaded', function() {
+    // Lock body height to prevent viewport changes from affecting background
+    const lockBodyHeight = () => {
+        document.body.style.height = `${window.innerHeight}px`;
+    };
+    
+    // Set initial height on load
+    lockBodyHeight();
+    window.addEventListener('load', lockBodyHeight);
+    
+    // Only update on orientation changes, not on scroll
+    window.addEventListener('orientationchange', () => setTimeout(lockBodyHeight, 100));
+    
     // Load saved theme and layout
     loadTheme();
     loadLayout();

--- a/static/styles.css
+++ b/static/styles.css
@@ -8,21 +8,28 @@
 
 html {
     height: 100%;
+    overflow: hidden;
 }
 
 body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
     background: #1a1a2e;
     color: var(--text-primary);
-    min-height: 100%;
+    height: 100%;
     padding: 1rem;
-    position: relative;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
     display: flex;
     flex-direction: column;
+    overflow-y: auto;
+    overflow-x: hidden;
+    -webkit-overflow-scrolling: touch;
 }
 
-body::before {
-    content: '';
+.fixed-bg {
     position: fixed;
     top: 0;
     left: 0;
@@ -35,6 +42,9 @@ body::before {
     filter: blur(2px) saturate(100%) brightness(70%);
     opacity: 0.5;
     z-index: -1;
+    /* Prevent background from resizing on mobile */
+    -webkit-backface-visibility: hidden;
+    backface-visibility: hidden;
 }
 
 .container {

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,6 +10,7 @@
     <script src="/static/app.js"></script>
 </head>
 <body>
+    <div class="fixed-bg"></div>
     <header class="container">
         {{if .Config.Settings.ShowTitle}}
         <h1>{{.Config.Settings.Title}}</h1>


### PR DESCRIPTION
This commit fixes the issue where the background image would resize when scrolling on mobile devices due to viewport height changes when the browser UI shows/hides.

Changes:
- Convert body to fixed positioning with internal scrolling
- Replace body::before pseudo-element with separate .fixed-bg div
- Lock body height using window.innerHeight to prevent viewport changes
- Background uses height: 100% which stays constant with fixed body
- Only updates body height on orientation change, not scroll/resize

This approach prevents background-size: cover from re-calculating during scroll, eliminating flicker and resize issues on mobile.