### PR TITLE
Add configurable favicon support

### DIFF
--- a/main.go
+++ b/main.go
@@ -101,6 +101,7 @@ type Settings struct {
 	Title     string `yaml:"title"`
 	Port      int    `yaml:"port"`       // Server port (default: 8080)
 	ShowTitle bool   `yaml:"show_title"` // Show title in header (default: true)
+	Favicon   string `yaml:"favicon"`    // Favicon URL or data URI (default: home emoji)
 }
 
 // SystemMetrics holds all system metrics collected for display

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,6 +4,11 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{.Config.Settings.Title}}</title>
+    {{if .Config.Settings.Favicon}}
+    <link rel="icon" type="image/svg+xml" href="{{.Config.Settings.Favicon}}">
+    {{else}}
+    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E🏠%3C/text%3E%3C/svg%3E">
+    {{end}}
     <link rel="stylesheet" href="/static/styles.css?v=29">
     <link rel="stylesheet" id="theme-css" href="">
     <script src="/static/iconify.min.js"></script>


### PR DESCRIPTION
Adds a 'favicon' field to the settings configuration that allows users to customize the website favicon. Supports both data URIs and URLs.

- Added Favicon field to Settings struct
- Updated template to use configured favicon if provided
- Default favicon is a home emoji (🏠) if not specified
- Maintains backward compatibility with existing configs